### PR TITLE
Make sure that vertical scroll bar is always shown

### DIFF
--- a/cassius/default-layout.cassius
+++ b/cassius/default-layout.cassius
@@ -1,3 +1,5 @@
+html
+    overflow-y: scroll
 body, html
     min-height: 100%
 body


### PR DESCRIPTION
This prevents shifting of the layout when e.g. switching between "Email"
and "Profile" on http://www.haskellers.com/profile
