### PR TITLE
not for merge -- ugly and rough way to modify a Field's input

### DIFF
--- a/haskellers.cabal
+++ b/haskellers.cabal
@@ -112,6 +112,8 @@ library
                  , monad-logger
                  , aeson
                  , cipher-aes
+                 , xss-sanitize
+                 , regex-compat
 
 executable         haskellers
     if flag(library-only)


### PR DESCRIPTION
Hey, i know that #20 is not an important issue, but i decided not to give up, and this led me to an interesting problem with Yesod. This pull request features ugly and intentionally raw code, aimed just at collecting some feedback.

In older to apply an additional modification on the input data, i could only write a new field, where `fieldParse` is copied from the original `nicHtmlField` and modified.

There has to be a better way, right? Is this use case so rare? Ideally i could use some helper function to extend parsing along the lines of the functions already existing that extend validation, but i was a bit lost in the signatures of parsing functions so i was not able to find an elegant approach.

I am a beginner with Haskell so i apologise in case the amount of ugliness is above the threshold!