### PR TITLE
Add dummy admin user

### DIFF
--- a/Application.hs
+++ b/Application.hs
@@ -202,7 +202,7 @@ migrateData pool = do
                 insert $ User
                     { Model.userFullName = name
                     , userWebsite = Nothing
-                    , userEmail = Nothing
+                    , userEmail = Just $ name `mappend` "@example.com"
                     , userVerifiedEmail = False
                     , userVerkey = Nothing
                     , userHaskellSince = Nothing

--- a/Foundation.hs
+++ b/Foundation.hs
@@ -29,6 +29,7 @@ import Yesod
 import Yesod.Static
 import Yesod.Auth
 import Yesod.Auth.BrowserId hiding (forwardUrl)
+import Yesod.Auth.Dummy
 import Yesod.Auth.OpenId
 import Yesod.Auth.Facebook.ServerSide
 import qualified Yesod.Auth.GoogleEmail2 as Google
@@ -423,7 +424,8 @@ instance YesodAuth App where
             return ()
 
     authPlugins app =
-        [ authOpenId OPLocal []
+        [ authDummy
+        , authOpenId OPLocal []
         , authFacebook []
         , authBrowserId def
         , uncurry Google.authGoogleEmail (appGoogleEmailCreds app)

--- a/templates/login.hamlet
+++ b/templates/login.hamlet
@@ -14,3 +14,9 @@
     <h3>&mdash; OR &mdash;
     <img #browserid src=@{StaticR browserid_png} alt=BrowserID>
     <span style="color:black"> via BrowserID
+    <h3>&mdash; OR &mdash;
+
+    <form method="post" action="@{AuthR $ PluginR "dummy" []}">
+      Your new identifier is: #
+      <input type="text" name="ident">
+      <input type="submit" value="Dummy Login">


### PR DESCRIPTION
I was looking for a way to login a user to a clean, local environment.
Currently there are no users, so PR currently creates an `admin` (I'll of crouse add a setting to control this option)

I was wondering what would be the best way to now login the user. Drush (Drupal's CLI) has a niffy feature where you can `drush user-login [user-name]` which will give you a one time login url (something like `http://example.com/user/reset/1/1472331807/BFc3e7OQhymw8zAENaw4PnzG0h59Ya4eZVyQxZedqLc`). I'd love a pointer on what you think would be the way forward.

Or, if you think it's not worth while, we can of course close it - I'm just doing it mostly for learning purposes 😄 